### PR TITLE
Fix file path and auth context errors

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, RefreshControl } from 'react-native';
 import { Eye, EyeOff, Send, Download, Receipt, Smartphone, Banknote } from 'lucide-react-native';
-import { useAuth } from '../../hooks/useAuth';
+import { useAuth } from '../../providers/AuthProvider';
 import { getBalance, getRecentTransactions } from '../../services/mpesaService';
+import type { Transaction } from '../../services/mpesaService';
 import { BalanceCard } from '../../components/BalanceCard';
 import { QuickActionCard } from '../../components/QuickActionCard';
 import { TransactionItem } from '../../components/TransactionItem';
@@ -11,7 +12,7 @@ export default function HomeScreen() {
   const { user } = useAuth();
   const [balance, setBalance] = useState<string>('0.00');
   const [isBalanceVisible, setIsBalanceVisible] = useState(true);
-  const [recentTransactions, setRecentTransactions] = useState([]);
+  const [recentTransactions, setRecentTransactions] = useState<Transaction[]>([]);
   const [refreshing, setRefreshing] = useState(false);
   const [loading, setLoading] = useState(true);
 

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Alert } from 'react-native';
 import { Settings, Shield, Bell, CircleHelp as HelpCircle, LogOut, ChevronRight, User } from 'lucide-react-native';
-import { useAuth } from '../../hooks/useAuth';
+import { useAuth } from '../../providers/AuthProvider';
 import { useRouter } from 'expo-router';
 
 export default function ProfileScreen() {

--- a/app/(tabs)/receive.tsx
+++ b/app/(tabs)/receive.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, TextInput, Share } from 'react-native';
 import QRCode from 'react-native-qrcode-svg';
 import { Download } from 'lucide-react-native';
-import { useAuth } from '../../hooks/useAuth';
+import { useAuth } from '../../providers/AuthProvider';
 import { generateQRSession } from '../../services/qrService';
 
 export default function ReceiveScreen() {

--- a/app/auth/login.tsx
+++ b/app/auth/login.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { View, Text, StyleSheet, TextInput, TouchableOpacity, Alert } from 'react-native';
 import { useRouter } from 'expo-router';
 import { Smartphone, Lock } from 'lucide-react-native';
-import { useAuth } from '@/hooks/useAuth';
+import { useAuth } from '../../providers/AuthProvider';
 
 export default function LoginScreen() {
   const router = useRouter();

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, createContext, useContext } from 'react';
+import { useState, useEffect } from 'react';
 import * as SecureStore from 'expo-secure-store';
 
 interface User {
@@ -8,23 +8,8 @@ interface User {
   email?: string;
 }
 
-interface AuthContextType {
-  user: User | null;
-  isAuthenticated: boolean;
-  login: (phoneNumber: string, otp: string) => Promise<boolean>;
-  logout: () => Promise<void>;
-  loading: boolean;
-}
-
-const AuthContext = createContext<AuthContextType | null>(null);
-
-export function useAuth() {
-  const context = useContext(AuthContext);
-  if (!context) {
-    throw new Error('useAuth must be used within AuthProvider');
-  }
-  return context;
-}
+// Note: The AuthContext and useAuth hook are defined in providers/AuthProvider.
+// This file is responsible only for the stateful implementation used by the provider.
 
 export function useAuthState() {
   const [user, setUser] = useState<User | null>(null);

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,21 @@
+// Metro configuration
+// Collapse or filter out anonymous frames during symbolication to avoid ENOENT on "<anonymous>"
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+config.server = config.server || {};
+config.server.symbolicator = config.server.symbolicator || {};
+
+config.server.symbolicator.customizeFrame = (frame) => {
+  // Hide frames with bogus file paths like "<anonymous>"
+  if (frame.file && typeof frame.file === 'string' && frame.file.includes('<anonymous>')) {
+    return { collapse: true };
+  }
+  return frame;
+};
+
+module.exports = config;
+

--- a/services/mpesaService.ts
+++ b/services/mpesaService.ts
@@ -5,7 +5,7 @@ interface SendMoneyRequest {
   amount: number;
 }
 
-interface Transaction {
+export interface Transaction {
   id: string;
   type: 'sent' | 'received' | 'bills' | 'airtime' | 'withdraw';
   amount: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,13 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "jsx": "react-jsx",
+    "lib": ["ES2021", "DOM"],
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "types": ["react", "react-native", "expo-router"],
     "paths": {
       "@/*": ["./*"]
     }


### PR DESCRIPTION
Centralize `useAuth` hook, improve TypeScript configuration, and configure Metro to handle anonymous frames to fix runtime errors and enhance build stability.

The `useAuth` error was caused by duplicate context definitions and incorrect import paths, leading to the hook being called outside its provider. The Metro `ENOENT` error occurred because the symbolicator attempted to read non-existent `<anonymous>` source files during error reporting. These changes consolidate the auth context, correctly type components, and prevent Metro from crashing on malformed stack frames.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e36b464-3d35-4c30-8611-87767c49e3d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e36b464-3d35-4c30-8611-87767c49e3d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

